### PR TITLE
feature: read file as string

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,11 +8,11 @@ function readJSON(filename, options, callback){
     options = {};
   }
 
-  fs.readFile(filename, options, function(error, bf){
+  fs.readFile(filename, 'utf8', function(error, bf){
     if(error) return callback(error);
 
     try {
-      bf = JSON.parse(bf.toString().replace(/^\ufeff/g, ''));
+      bf = JSON.parse(bf);
     } catch (err) {
       callback(err);
       return;


### PR DESCRIPTION
Read file in `utf8` instead of call `toString`.
