### PR TITLE
mv try catch out of main function

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,11 +10,14 @@ function readJSON(filename, options, callback){
   }
 
   fs.readFile(filename, options, function(error, bf){
-    var json;
+    var json,
+        str = bf
+            .tString()
+            .replace(/^\ufeff/g, '');
     
     if (!error)
-      error = tryit(function() {
-        json = JSON.parse(bf);
+      tryit(function() {
+        json = JSON.parse(str);
       }, function(err) {
         error = err;
       });

--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ function readJSON(filename, options, callback){
     var json;
     
     if (!error)
-      error = try(function() {
+      error = tryCatch(function() {
         json = JSON.parse(bf);
       });
     
@@ -20,7 +20,7 @@ function readJSON(filename, options, callback){
   });
 }
 
-function try(fn) {
+function tryCatch(fn) {
   var error;
   
   try {

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
-var fs = require("fs");
+var fs = require("fs"),
+    tryit = require("tryit");
 
 module.exports = readJSON;
 
@@ -12,23 +13,12 @@ function readJSON(filename, options, callback){
     var json;
     
     if (!error)
-      error = tryCatch(function() {
+      error = tryit(function() {
         json = JSON.parse(bf);
+      }, function(err) {
+        error = err;
       });
     
     callback(error, json);
   });
-}
-
-function tryCatch(fn) {
-  var error;
-  
-  try {
-      fn();
-    } catch (err) {
-      error = err;
-      return;
-    }
-  
-  return error;
 }

--- a/index.js
+++ b/index.js
@@ -9,15 +9,26 @@ function readJSON(filename, options, callback){
   }
 
   fs.readFile(filename, options, function(error, bf){
-    if(error) return callback(error);
+    var json;
+    
+    if (!error)
+      error = try(function() {
+        json = JSON.parse(bf);
+      });
+    
+    callback(error, json);
+  });
+}
 
-    try {
-      bf = JSON.parse(bf.toString().replace(/^\ufeff/g, ''));
+function try(fn) {
+  var error;
+  
+  try {
+      fn();
     } catch (err) {
-      callback(err);
+      error = err;
       return;
     }
-
-    callback(undefined, bf);
-  });
+  
+  return error;
 }

--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   "scripts": {
     "test": "prova test"
   },
+  "dependencies": {
+    "tryit": "~1.0.0"
+  },
   "devDependencies": {
     "prova": "^1.14.3"
   },


### PR DESCRIPTION
Moved `try-catch` to another function to improve speed.
Callback called twice when error occur:
- with first argument `error`
- with first argument `undefined`

[Optimization killers](https://github.com/petkaantonov/bluebird/wiki/Optimization-killers)
